### PR TITLE
fix: removed unnecessary vertice from polygon

### DIFF
--- a/src/components/Mask.tsx
+++ b/src/components/Mask.tsx
@@ -21,7 +21,7 @@ export function Mask(props: MaskProps): JSX.Element {
   const {width: containerWidth, height: containerHeight} = getViewportScrollDims(tourRoot);
   const pathId = `clip-path-${maskId}`;
 
-  const calculateCutout = (target: HTMLElement): string => {
+  const calculateCutout = (target: HTMLElement, primary: boolean): string => {
     if (!target) {
       return '';
     }
@@ -33,7 +33,7 @@ export function Mask(props: MaskProps): JSX.Element {
     const cutoutLeft: number = coords.x - padding;
     const cutoutRight: number = coords.x + targetDims.width + padding;
     const cutoutBottom: number = coords.y + targetDims.height + padding;
-
+    if (primary) {
     return `${cutoutLeft} ${containerHeight}, 
             ${cutoutLeft} ${cutoutTop}, 
             ${cutoutRight} ${cutoutTop}, 
@@ -42,6 +42,15 @@ export function Mask(props: MaskProps): JSX.Element {
             ${cutoutLeft} ${containerHeight}, 
             ${containerWidth} ${containerHeight}, 
             ${containerWidth} 0`;
+    }else{
+      return `${cutoutLeft} ${containerHeight}, 
+            ${cutoutLeft} ${cutoutTop}, 
+            ${cutoutRight} ${cutoutTop}, 
+            ${cutoutRight} ${cutoutBottom}, 
+            ${cutoutLeft} ${cutoutBottom}, 
+            ${cutoutLeft} ${containerHeight}, 
+            ${containerWidth} 0`;
+    }
   }
 
   const getCutoutPoints = (target: HTMLElement): string => {
@@ -52,12 +61,12 @@ export function Mask(props: MaskProps): JSX.Element {
     if (secondaryTargets === undefined) {
       return `0 0, 
               0 ${containerHeight}, 
-              ` + calculateCutout(target);
+              ` + calculateCutout(target, true);
     }else{
       return `0 0, 
             0 ${containerHeight},` +
-            calculateCutout(target) + `,` + secondaryTargets.map((secondaryTarget) => {
-              return calculateCutout(secondaryTarget);
+            calculateCutout(target, true) + `,` + secondaryTargets.map((secondaryTarget) => {
+              return calculateCutout(secondaryTarget, false);
             });
     }
   }

--- a/stories/options/secondary-targets.stories.tsx
+++ b/stories/options/secondary-targets.stories.tsx
@@ -8,8 +8,9 @@ export default {
 }
 
 const primarySteps = (): Step[] => [
-    { selector: '#one', title: 'Guided Tour Component', description: 'Welcome to the tour!', secondarySelectors: ['#two', '.four', '#nine']},
-    { selector: '#two', title: 'Keyboard Navigation', description: 'Use the arrow keys or tab to a specific button' },
+    { selector: '#one', title: 'Guided Tour Component', description: 'Welcome to the tour!', secondarySelectors: ['#two', '#three', '.four', '#five', '#six', '#nine']},
+    { selector: '#two', title: 'Keyboard Navigation', description: 'Use the arrow keys or tab to a specific button', secondarySelectors: ['#one', '.four', '#nine'] },
+    { selector: "#three", description:"this is a test", secondarySelectors: ['#two', '.four', '#five', '#six', '#nine'] },
     { selector: "#nine", title: "Accessibility!", description: "The tooltip traps focus for keyboard users. The trap includes the target element(s)!" },
     { selector: '.four', title: 'Full CSS Selector Support', description: 'Any valid query selector works for targeting elements' },
   ]


### PR DESCRIPTION
An extraneous vertice that extended from the top right to the bottom left caused when using `secondarySelectors` was causing elements on the far right to be partially covered. This PR removes coordinate points calculated from elements used in `secondarySelectors`, fixing the issue. 